### PR TITLE
Norkyst800 url varies by year

### DIFF
--- a/dnora/ocr/read_metno.py
+++ b/dnora/ocr/read_metno.py
@@ -1,10 +1,11 @@
-from abc import ABC,  abstractmethod
+from abc import ABC, abstractmethod
 from copy import copy
 import numpy as np
 import xarray as xr
 from subprocess import call
 import os, glob
 import time
+
 # Import objects
 from ..grd.grd_mod import Grid
 
@@ -13,7 +14,13 @@ from .read import OceanCurrentReader
 
 # Import aux_funcsiliry functions
 from .. import msg
-from ..aux_funcs import create_time_stamps, u_v_from_dir, expand_area, lon_in_km, pyfimex
+from ..aux_funcs import (
+    create_time_stamps,
+    u_v_from_dir,
+    expand_area,
+    lon_in_km,
+    pyfimex,
+)
 
 
 class NorKyst800(OceanCurrentReader):
@@ -27,7 +34,14 @@ class NorKyst800(OceanCurrentReader):
     No. 1 : User Manual and technical descriptions.
     """
 
-    def __init__(self, stride: int=24, hours_per_file: int=24, last_file: str='', lead_time: int=0, program: str='pyfimex'):
+    def __init__(
+        self,
+        stride: int = 24,
+        hours_per_file: int = 24,
+        last_file: str = "",
+        lead_time: int = 0,
+        program: str = "pyfimex",
+    ):
         """The data is currently in daily files. Do not change the default
         setting unless you have a good reason to do so.
         """
@@ -39,18 +53,27 @@ class NorKyst800(OceanCurrentReader):
         self.program = program
         return
 
-    def __call__(self, grid: Grid, start_time: str, end_time: str, expansion_factor: float):
+    def __call__(
+        self, grid: Grid, start_time: str, end_time: str, expansion_factor: float
+    ):
         """Reads in all grid points between the given times and at for the given indeces"""
         self.start_time = start_time
         self.end_time = end_time
 
         start_times, end_times, file_times = create_time_stamps(
-            start_time, end_time, self.stride, self.hours_per_file, self.last_file, self.lead_time)
+            start_time,
+            end_time,
+            self.stride,
+            self.hours_per_file,
+            self.last_file,
+            self.lead_time,
+        )
 
         msg.info(
-            f"Getting ocean_current forcing from Norkyst800 from {self.start_time} to {self.end_time}")
+            f"Getting ocean_current forcing from Norkyst800 from {self.start_time} to {self.end_time}"
+        )
 
-        temp_folder = 'dnora_ocr_temp'
+        temp_folder = "dnora_ocr_temp"
         if not os.path.isdir(temp_folder):
             os.mkdir(temp_folder)
             print("Creating folder %s..." % temp_folder)
@@ -59,70 +82,110 @@ class NorKyst800(OceanCurrentReader):
         for f in glob.glob("dnora_ocr_temp/*MetNo_Norkyst800.nc"):
             os.remove(f)
 
-
         # Define area to search in
-        lon_min, lon_max, lat_min, lat_max = expand_area(min(grid.lon()), max(grid.lon()), min(grid.lat()), max(grid.lat()), expansion_factor)
+        lon_min, lon_max, lat_min, lat_max = expand_area(
+            min(grid.lon()),
+            max(grid.lon()),
+            min(grid.lat()),
+            max(grid.lat()),
+            expansion_factor,
+        )
 
         # Setting resolution to roughly 0.8 km
-        dlat = 0.8/111
-        mean_lon_in_km = (lon_in_km(grid.lat()[0])+lon_in_km(grid.lat()[-1]))*0.5
-        dlon = 0.8/mean_lon_in_km
+        dlat = 0.8 / 111
+        mean_lon_in_km = (lon_in_km(grid.lat()[0]) + lon_in_km(grid.lat()[-1])) * 0.5
+        dlon = 0.8 / mean_lon_in_km
 
         ocr_list = []
-        print('Apply >>> '+ self.program)
+        print("Apply >>> " + self.program)
         for n in range(len(file_times)):
             url = self.get_url(file_times[n])
 
             msg.from_file(url)
             msg.plain(
-                f"Reading ocean_current forcing data: {start_times[n]}-{end_times[n]}")
+                f"Reading ocean_current forcing data: {start_times[n]}-{end_times[n]}"
+            )
 
-            nc_fimex = f'dnora_ocr_temp/ocean_current_{n:04.0f}_MetNo_Norkyst800.nc'
+            nc_fimex = f"dnora_ocr_temp/ocean_current_{n:04.0f}_MetNo_Norkyst800.nc"
             # Apply pyfimex or fimex
-            if self.program == 'pyfimex':
-                pyfimex(input_file=url,output_file=nc_fimex,
+            if self.program == "pyfimex":
+                pyfimex(
+                    input_file=url,
+                    output_file=nc_fimex,
                     projString="+proj=latlong +ellps=sphere +a=6371000 +e=0",
-                    xAxisValues=np.arange(lon_min,lon_max+dlon,dlon),
-                    yAxisValues=np.arange(lat_min,lat_max+dlat,dlat),
-                    selectVariables=['u', 'v'],
-                    reduceTime_start = start_times[n].strftime('%Y-%m-%dT%H:%M:%S'),
-                    reduceTime_end   = end_times[n].strftime('%Y-%m-%dT%H:%M:%S'))
-            elif self.program == 'fimex':
-                fimex_command = ['fimex', '--input.file='+url,
-                                 '--interpolate.method=bilinear',
-                                 '--interpolate.projString=+proj=latlong +ellps=sphere +a=6371000 +e=0',
-                                 '--interpolate.xAxisValues='+ str(lon_min)+','+str(lon_min+dlon)+ ',...,'+str(lon_max)+'',
-                                 '--interpolate.yAxisValues='           + str(lat_min)+','+str(lat_min+dlat)+ ',...,'+str(lat_max)+'',
-                                 '--interpolate.xAxisUnit=degree', '--interpolate.yAxisUnit=degree',
-                                 '--process.rotateVector.all',
-                                 '--extract.selectVariables=u', '--extract.selectVariables=v',
-                                 '--extract.reduceTime.start=' + \
-                                 start_times[n].strftime('%Y-%m-%dT%H:%M:%S'),
-                                 '--extract.reduceTime.end=' + \
-                                 end_times[n].strftime('%Y-%m-%dT%H:%M:%S'),
-                                 '--process.rotateVector.direction=latlon',
-                                 #'--extract.reduceDimension.name=depth',
-                                 #'--extract.reduceDimension.start=0',
-                                 #'--extract.reduceDimension.end=0',
-                                 '--output.file='+nc_fimex]
+                    xAxisValues=np.arange(lon_min, lon_max + dlon, dlon),
+                    yAxisValues=np.arange(lat_min, lat_max + dlat, dlat),
+                    selectVariables=["u", "v"],
+                    reduceTime_start=start_times[n].strftime("%Y-%m-%dT%H:%M:%S"),
+                    reduceTime_end=end_times[n].strftime("%Y-%m-%dT%H:%M:%S"),
+                )
+            elif self.program == "fimex":
+                fimex_command = [
+                    "fimex",
+                    "--input.file=" + url,
+                    "--interpolate.method=bilinear",
+                    "--interpolate.projString=+proj=latlong +ellps=sphere +a=6371000 +e=0",
+                    "--interpolate.xAxisValues="
+                    + str(lon_min)
+                    + ","
+                    + str(lon_min + dlon)
+                    + ",...,"
+                    + str(lon_max)
+                    + "",
+                    "--interpolate.yAxisValues="
+                    + str(lat_min)
+                    + ","
+                    + str(lat_min + dlat)
+                    + ",...,"
+                    + str(lat_max)
+                    + "",
+                    "--interpolate.xAxisUnit=degree",
+                    "--interpolate.yAxisUnit=degree",
+                    "--process.rotateVector.all",
+                    "--extract.selectVariables=u",
+                    "--extract.selectVariables=v",
+                    "--extract.reduceTime.start="
+                    + start_times[n].strftime("%Y-%m-%dT%H:%M:%S"),
+                    "--extract.reduceTime.end="
+                    + end_times[n].strftime("%Y-%m-%dT%H:%M:%S"),
+                    "--process.rotateVector.direction=latlon",
+                    #'--extract.reduceDimension.name=depth',
+                    #'--extract.reduceDimension.start=0',
+                    #'--extract.reduceDimension.end=0',
+                    "--output.file=" + nc_fimex,
+                ]
                 call(fimex_command)
             ocr_list.append(xr.open_dataset(nc_fimex).squeeze())
 
         oceancurrent_forcing = xr.concat(ocr_list, dim="time")
         # Rename X/Y  to lon/lat
-        oceancurrent_forcing = oceancurrent_forcing.rename_dims({'Y': 'lat', 'X': 'lon'})
-        oceancurrent_forcing = oceancurrent_forcing.rename_vars({'Y': 'lat', 'X': 'lon'})
+        oceancurrent_forcing = oceancurrent_forcing.rename_dims(
+            {"Y": "lat", "X": "lon"}
+        )
+        oceancurrent_forcing = oceancurrent_forcing.rename_vars(
+            {"Y": "lat", "X": "lon"}
+        )
         # Select depth = 0 m
         oceancurrent_forcing = oceancurrent_forcing.sel(depth=0)
 
-        oceancurrent_forcing['u'] = oceancurrent_forcing['u'].fillna(0)
-        oceancurrent_forcing['v'] = oceancurrent_forcing['v'].fillna(0)
+        oceancurrent_forcing["u"] = oceancurrent_forcing["u"].fillna(0)
+        oceancurrent_forcing["v"] = oceancurrent_forcing["v"].fillna(0)
 
-        oceancurrent_forcing = oceancurrent_forcing.transpose('time', 'lat', 'lon')
+        oceancurrent_forcing = oceancurrent_forcing.transpose("time", "lat", "lon")
 
         return oceancurrent_forcing
 
     def get_url(self, time_stamp):
-        filename = 'NorKyst-800m_ZDEPTHS_his.an.'+time_stamp.strftime('%Y%m%d')+'00.nc'
-        url = 'https://thredds.met.no/thredds/dodsC/sea/norkyst800mv0_1h/'+ filename
+        filename = (
+            "NorKyst-800m_ZDEPTHS_his.an." + time_stamp.strftime("%Y%m%d") + "00.nc"
+        )
+        if time_stamp.year < 2018:
+
+            url = (
+                "https://thredds.met.no/thredds/dodsC/sea/norkyst800mv0_1h/" + filename
+            )
+        else:
+            url = (
+                "https://thredds.met.no/thredds/dodsC/fou-hi/norkyst800m-1h/" + filename
+            )
         return url

--- a/examples/example_mdl_swan.py
+++ b/examples/example_mdl_swan.py
@@ -2,28 +2,28 @@
 # IMPORT dnora
 # =============================================================================
 from dnora import grd, mdl, wnd, bnd, inp, wlv, ocr, run
+
 # =============================================================================
 # DEFINE GRID OBJECT
 # =============================================================================
 # Set grid definitions
-grid = grd.Grid(lon=(5.35, 5.6), lat=(59.00, 59.17), name='Boknafjorden')
+grid = grd.Grid(lon=(5.35, 5.6), lat=(59.00, 59.17), name="Boknafjorden")
 
 # Set spacing and boundary points
 grid.set_spacing(dm=250)
 
 # Import topography and mesh it down to the grid definitions
 # Options for grd.readers: EMODNET2020, KartverketNo50m, GEBCO2021
-topo_reader = grd.read.EMODNET2020(
-    tile='*5', folder='/home/janvb/Documents/bathy/EMODNET2020')
+topo_reader = grd.read.EMODNET2020(tile="*5", folder="/home/konstac/bathy")
 grid.import_topo(topo_reader=topo_reader)
 
 # This can be used to get an empty topography for testing
-#grid.import_topo(topo_reader=grd.read.EmptyTopo(grid=grid))
+# grid.import_topo(topo_reader=grd.read.EmptyTopo(grid=grid))
 #
 grid.mesh_grid()
 #
 # Set the boundaries
-bnd_set = grd.boundary.EdgesAsBoundary(edges=[ 'W', 'S'], step = 10)
+bnd_set = grd.boundary.EdgesAsBoundary(edges=["W", "S"], step=10)
 grid.set_boundary(boundary_setter=bnd_set)
 #
 #
@@ -31,24 +31,23 @@ grid.set_boundary(boundary_setter=bnd_set)
 # DEFINE MODEL OBJECT (mdl.)
 # =============================================================================
 # Options for mdl: SWAN_NORA3, SWAN_ERA5, SWAN_WW3_4km, SWAN_WAM4km
-model = mdl.SWAN_NORA3(grid, start_time='2020-12-17T12:00',
-                               end_time='2020-12-17T18:00')
+model = mdl.SWAN_NORA3(grid, start_time="2020-12-17T12:00", end_time="2020-12-17T18:00")
 # =============================================================================
 # IMPORT BOUNDARIES AND FORCING
 # =============================================================================
 # Boundary Spectra
 model.import_boundary(write_cache=True, read_cache=False)
-#model.import_boundary(bnd.read_metno.NORA3(source='lustre'),write_cache=True, read_cache=False) # for internal
+# model.import_boundary(bnd.read_metno.NORA3(source='lustre'),write_cache=True, read_cache=False) # for internal
 
 # Wind Forcing
 model.import_forcing(write_cache=True, read_cache=False)
-#model.import_forcing(wnd.read_metno.NORA3(source='lustre'),write_cache=True, read_cache=False)  # for internal
+# model.import_forcing(wnd.read_metno.NORA3(source='lustre'),write_cache=True, read_cache=False)  # for internal
 
 # Ocean Current
-#model.import_oceancurrent(ocr.read_metno.NorKyst800())
+# model.import_oceancurrent(ocr.read_metno.NorKyst800())
 
 # Water Level
-#model.import_waterlevel(wlv.read_ec.GTSM_ERA5())
+# model.import_waterlevel(wlv.read_ec.GTSM_ERA5())
 # =============================================================================
 # PLOT GRID, FORCING AND BOUNDARIES
 # =============================================================================
@@ -59,11 +58,12 @@ model.plot_grid(save_fig=True, show_fig=False)
 model.export_grid()
 model.export_boundary()
 model.export_forcing()
-#model.export_oceancurrent()
-#model.export_waterlevel()
-model.write_input_file(input_file_writer=inp.SWAN(
-    spec_points=[(5.50, 59.16), (5.55, 59.15)]))
+# model.export_oceancurrent()
+# model.export_waterlevel()
+model.write_input_file(
+    input_file_writer=inp.SWAN(spec_points=[(5.50, 59.16), (5.55, 59.15)])
+)
 # =============================================================================
 # SWAN RUN
 # =============================================================================
-model.run_model(model_executer = run.SWAN(nproc=15))
+model.run_model(model_executer=run.SWAN(nproc=15))

--- a/examples/example_mdl_swan.py
+++ b/examples/example_mdl_swan.py
@@ -14,7 +14,7 @@ grid.set_spacing(dm=250)
 # Import topography and mesh it down to the grid definitions
 # Options for grd.readers: EMODNET2020, KartverketNo50m, GEBCO2021
 topo_reader = grd.read.EMODNET2020(
-    tile='*5', folder='/home/konstac/bathy')
+    tile='*5', folder='/home/janvb/Documents/bathy/EMODNET2020')
 grid.import_topo(topo_reader=topo_reader)
 
 # This can be used to get an empty topography for testing


### PR DESCRIPTION
The NorKyst800-dataset has an old and new version with different urls on thredds.

Made a change that the old is used up until 2017 and the new starting 2018. 2018 was included in the new dataset since the last day of December 2018 is missing. If that gets fixed, it will probably be to the new version.

The code below runs, so merging between old and new data works.

--------------------
from dnora import grd, mdl, ocr

grid = grd.Grid(lon=(2.629880, 5.755490), lat=(59.517501, 60.748326), name="Bergen")

model = mdl.ModelRun(grid, start_time="2017-12-31 00:00", end_time="2018-01-02 00:00")
model.import_oceancurrent(ocr.read_metno.NorKyst800())

(dnora) python get_current_dnora1.py 
---------------------------------------------------------------------------
NorKyst800 (OceanCurrentReader): Loading ocean_current forcing...
---------------------------------------------------------------------------
/home/janvb/Documents/pycode/dnora/dnora/aux_funcs.py:297: FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.
  file_times = pd.date_range(start = start_stamp - pd.DateOffset(hours=h0), end = end_stamp - pd.DateOffset(hours=h1), freq=f'{stride}H')
*** Getting ocean_current forcing from Norkyst800 from 2017-12-31 00:00 to 2018-01-02 00:00 ***
Removing old files from temporary folder...
Apply >>> pyfimex
Reading from file <<< https://thredds.met.no/thredds/dodsC/sea/norkyst800mv0_1h/NorKyst-800m_ZDEPTHS_his.an.2017123100.nc
Reading ocean_current forcing data: 2017-12-31 00:00:00-2017-12-31 23:00:00
Reading from file <<< https://thredds.met.no/thredds/dodsC/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2018010100.nc
Reading ocean_current forcing data: 2018-01-01 00:00:00-2018-01-01 23:00:00
Reading from file <<< https://thredds.met.no/thredds/dodsC/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2018010200.nc
Reading ocean_current forcing data: 2018-01-02 00:00:00-2018-01-02 00:00:00
--Return--