### PR TITLE
V2 spec convention

### DIFF
--- a/dnora/export/spectra_writers.py
+++ b/dnora/export/spectra_writers.py
@@ -55,10 +55,18 @@ class SpectraWriter(DataWriter):
             self._convention = SpectralConvention[self._convention.upper()]
         return self._convention
 
+    def set_convention(self, convention: SpectralConvention | str) -> None:
+        if isinstance(convention, str):
+            self._convention = SpectralConvention[convention.upper()]
+        else:
+            self._convention = convention
+
 
 class WW3(SpectraWriter):
     def __init__(
-        self, convention=SpectralConvention.WW3, one_file: bool = None
+        self,
+        convention: SpectralConvention | str = SpectralConvention.WW3,
+        one_file: bool = None,
     ) -> None:
         if one_file is not None:
             warnings.warn(
@@ -67,7 +75,7 @@ class WW3(SpectraWriter):
                 stacklevel=2,
             )
         self.one_file = one_file
-        self._convention = convention
+        self.set_convention(convention)
 
     def __call__(
         self,
@@ -77,12 +85,15 @@ class WW3(SpectraWriter):
         var_names: dict = None,
         one_file: bool = True,
         squeeze_lonlat: bool = False,
+        convention: SpectralConvention | str | None = None,
         **kwargs,
     ) -> list[str]:
         """You can change the variable names by giving a dictionary e.g. var_names = {'efth': 'SPEC'}
         To write one file for each lon/lat points, set one_file = False
         To write longitude/latitude withouth a time dimension, set squeeze_lonlat = True
         """
+        if convention is not None:
+            model.spectra().set_convention(convention)
 
         msg.info("Writing WAVEWATCH-III netcdf-output")
         boundary = model.spectra()

--- a/dnora/read/generic/generic_readers.py
+++ b/dnora/read/generic/generic_readers.py
@@ -82,7 +82,7 @@ class PointNetcdf(SpectralDataReader):
             ds = xr.open_dataset(filepath)
 
         lon, lat, x, y = utils.grid.get_coordinates_from_ds(ds)
-        self.set_convention(ds.attrs.get("dnora_spectral_convention", "unknown"))
+        self.set_convention(ds.attrs.get("dnora_spectral_convention", "undefined"))
         return {"lon": lon, "lat": lat, "x": x, "y": y}
 
     def __call__(
@@ -100,17 +100,19 @@ class PointNetcdf(SpectralDataReader):
 
         filename = filename or self.files
         if isinstance(filename, list):
-            ds = read_cached_filelist(folder, filename).sel(inds=inds)
+            ds = read_cached_filelist(folder, filename)
         else:
             filepath = get_url(folder, filename)
-            ds = xr.open_dataset(filepath).sel(inds=inds)
+            ds = xr.open_dataset(filepath)
             msg.from_file(filepath)
 
         cls = dnora_objects.get(obj_type)
         # This geo-skeleton method does all the heavy lifting with decoding the Dataset to match the class data variables etc.
-        data = cls.from_ds(ds)
+        data = cls.from_ds(ds).sel(inds=inds)
         # Set reader convention. This is used by the import method to set correct convention to the instance
-        self.set_convention(data.meta.get().get("dnora_spectral_convention"))
+        self.set_convention(
+            data.meta.get().get("dnora_spectral_convention", "undefined")
+        )
 
         return data.ds()
 

--- a/dnora/read/generic/generic_readers.py
+++ b/dnora/read/generic/generic_readers.py
@@ -82,7 +82,7 @@ class PointNetcdf(SpectralDataReader):
             ds = xr.open_dataset(filepath)
 
         lon, lat, x, y = utils.grid.get_coordinates_from_ds(ds)
-        self.set_convention(ds.attrs.get("dnora_spectral_convention", "undefined"))
+        # self.set_convention(ds.attrs.get("dnora_spectral_convention", "undefined"))
         return {"lon": lon, "lat": lat, "x": x, "y": y}
 
     def __call__(
@@ -95,6 +95,7 @@ class PointNetcdf(SpectralDataReader):
         folder: str,
         inds: list[int],
         filename: list[str] = None,
+        convention: SpectralConvention | str | None = None,
         **kwargs,
     ):
 
@@ -110,9 +111,10 @@ class PointNetcdf(SpectralDataReader):
         # This geo-skeleton method does all the heavy lifting with decoding the Dataset to match the class data variables etc.
         data = cls.from_ds(ds).sel(inds=inds)
         # Set reader convention. This is used by the import method to set correct convention to the instance
-        self.set_convention(
-            data.meta.get().get("dnora_spectral_convention", "undefined")
+        convention = convention or data.meta.get().get(
+            "dnora_spectral_convention", "undefined"
         )
+        self.set_convention(convention)
 
         return data.ds()
 

--- a/tests/test_ww3_can_write_different_conventions.py
+++ b/tests/test_ww3_can_write_different_conventions.py
@@ -1,0 +1,156 @@
+
+import dnora as dn
+import glob
+import os
+import shutil
+import pytest 
+import numpy as np
+from dnora.type_manager.spectral_conventions import SpectralConvention
+
+def cleanup():
+    if os.path.isdir("ww3_pytest"):
+        shutil.rmtree("ww3_pytest")
+
+@pytest.fixture(scope="session")
+def grid():
+    grid =  dn.grid.Grid(lon=(10, 11), lat=(70, 71))
+    grid.set_spacing(dlon=1, dlat=1)
+    grid.set_boundary_points(dn.grid.mask.All())
+    return grid
+
+@pytest.fixture(scope="session")
+def model(grid):
+    model = dn.modelrun.Constant(
+        grid, start_time="2020-01-31 00:00", end_time="2020-02-02 01:00"
+    )
+    return model
+
+def check_that_spectra_is_consistent(spectra, convention):
+    assert spectra.isel(inds=0, time=0).spec().shape == (10, 36)
+    assert spectra.freq().shape == (10,)
+    assert spectra.dirs().shape == (36,)
+    assert spectra.convention() == convention
+
+def check_that_peak_dir_is_right(spectra, expected_peak_dir:float):
+    one_1dspec = spectra.isel(inds=0, time=0, freq=2)
+    dirs = one_1dspec.dirs()
+    ipeak = np.argmax(one_1dspec.spec())
+    np.testing.assert_almost_equal(dirs[ipeak], expected_peak_dir)
+
+def dirs_are_normal(spectra):
+    np.testing.assert_almost_equal(spectra.dirs(), np.arange(0,360,10))
+
+def dirs_are_math(spectra):
+    np.testing.assert_almost_equal(spectra.dirs(), np.mod(np.arange(360,0,-10)-270,360))
+
+def test_ww3_writes_ww3(model):
+    cleanup()
+    model.import_spectra()
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    exp = dn.export.WW3(model)
+    dirs_are_normal(model.spectra())
+
+    # Export to file and check that the spectra is converted right
+    exp.export_spectra(folder='ww3_pytest', filename='spec_in_ww3') # Default exports (i.e. converts) to WW3 format
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.WW3)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    dirs_are_math(model.spectra())
+
+    # Reread spectra to see that it is correctly written
+    model['spectra'] = None
+    model.import_spectra(dn.read.generic.PointNetcdf(), folder='ww3_pytest',filename='spec_in_ww3.nc', convention='ww3')
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.WW3)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    dirs_are_math(model.spectra())
+    cleanup()
+
+def test_ww3_writes_ocean(model):
+    cleanup()
+    model.import_spectra()
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    exp = dn.export.WW3(model)
+    dirs_are_normal(model.spectra())
+
+    # Export to file and check that the spectra is converted right
+    # exp.export_spectra(dn.export.spectra_writers.WW3(convention='ocean'),folder='ww3_pytest', filename='spec_in_ocean')  # Equivalent to the line below
+    exp.export_spectra(folder='ww3_pytest', filename='spec_in_ocean', convention='ocean') 
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    dirs_are_normal(model.spectra())
+
+    # Reread spectra to see that it is correctly written
+    model['spectra'] = None
+    model.import_spectra(dn.read.generic.PointNetcdf(), folder='ww3_pytest',filename='spec_in_ocean.nc', convention='ocean')
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    dirs_are_normal(model.spectra())
+    cleanup()
+
+def test_ww3_writes_met(model):
+    cleanup()
+    model.import_spectra()
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    exp = dn.export.WW3(model)
+    dirs_are_normal(model.spectra())
+
+    # Export to file and check that the spectra is converted right
+    exp.export_spectra(folder='ww3_pytest', filename='spec_in_met', convention='met') 
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MET)
+    check_that_peak_dir_is_right(model.spectra(),180.0)
+    dirs_are_normal(model.spectra())
+
+    # Reread spectra to see that it is correctly written
+    model['spectra'] = None
+    model.import_spectra(dn.read.generic.PointNetcdf(), folder='ww3_pytest',filename='spec_in_met.nc', convention='met')
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MET)
+    check_that_peak_dir_is_right(model.spectra(),180.0)
+    dirs_are_normal(model.spectra())
+    cleanup()
+
+
+def test_ww3_writes_math(model):
+    cleanup()
+    model.import_spectra()
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    exp = dn.export.WW3(model)
+    dirs_are_normal(model.spectra())
+
+    # Export to file and check that the spectra is converted right
+    exp.export_spectra(folder='ww3_pytest', filename='spec_in_math', convention='math') 
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MATH)
+    check_that_peak_dir_is_right(model.spectra(),90.0)
+    dirs_are_normal(model.spectra())
+
+    # Reread spectra to see that it is correctly written
+    model['spectra'] = None
+    model.import_spectra(dn.read.generic.PointNetcdf(), folder='ww3_pytest',filename='spec_in_math.nc', convention='math')
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MATH)
+    check_that_peak_dir_is_right(model.spectra(),90.0)
+    dirs_are_normal(model.spectra())
+    cleanup()
+
+def test_ww3_writes_mathvec(model):
+    cleanup()
+    model.import_spectra()
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.OCEAN)
+    check_that_peak_dir_is_right(model.spectra(),0.0)
+    exp = dn.export.WW3(model)
+    dirs_are_normal(model.spectra())
+
+    # Export to file and check that the spectra is converted right
+    exp.export_spectra(folder='ww3_pytest', filename='spec_in_mathvec', convention='mathvec') 
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MATHVEC)
+    check_that_peak_dir_is_right(model.spectra(),90.0)
+    dirs_are_math(model.spectra())
+
+    # Reread spectra to see that it is correctly written
+    model['spectra'] = None
+    model.import_spectra(dn.read.generic.PointNetcdf(), folder='ww3_pytest',filename='spec_in_mathvec.nc', convention='mathvec')
+    check_that_spectra_is_consistent(model.spectra(), SpectralConvention.MATHVEC)
+    check_that_peak_dir_is_right(model.spectra(),90.0)
+    dirs_are_math(model.spectra())
+    cleanup()


### PR DESCRIPTION
Added possibility to give convention as keyword to WW3 spectral reader (previously could only be given at initialization). Added tests to see that is works.