### PR TITLE
V2 swan mat

### DIFF
--- a/dnora/cacher/caching_functions.py
+++ b/dnora/cacher/caching_functions.py
@@ -73,7 +73,7 @@ def patch_cached_data(mrun_cacher, tiles, kwargs_cache, strategy: CachingStrateg
             end_time=patch_date[1],
         )
 
-        mrun_patch._import_data(**kwargs_cache)
+        mrun_patch._import_data(**kwargs_cache, coverage_warning=False)
 
         ## Merge patch together with what was found in the cached
         if patch_dimension == "time":

--- a/dnora/cacher/caching_functions.py
+++ b/dnora/cacher/caching_functions.py
@@ -36,7 +36,9 @@ def read_data_from_cache(mrun_cacher, tiles, cache_reader, kwargs_cache):
     """Read all possible data from cached files"""
     if tiles.relevant_files():
         kwargs_read_cache = copy(kwargs_cache)
-        kwargs_read_cache["reader"] = cache_reader(files=tiles.relevant_files())
+        kwargs_read_cache["reader"] = cache_reader(
+            files=tiles.relevant_files(), used_for_cache=True
+        )
         kwargs_read_cache["source"] = DataSource.LOCAL
         mrun_cacher._import_data(**kwargs_read_cache)
     return mrun_cacher

--- a/dnora/executer/inputfile/inputfile_writers.py
+++ b/dnora/executer/inputfile/inputfile_writers.py
@@ -86,6 +86,7 @@ class SWAN(InputFileWriter):
         file_object: FileNames,
         exported_files: dict[str, list[str]],
         calibrate: dict[str, float] = None,
+        write_mat: bool = False,
         use_wind: bool = True,
         use_waterlevel: bool = True,
         use_spectra: bool = True,
@@ -93,7 +94,13 @@ class SWAN(InputFileWriter):
         use_ice: bool = True,
         structures: list[dict] = None,
     ):
-        """structures given in format:
+        """
+        write_mat = True [default: False]: Write mat-files instead of Netcdf-files
+
+        The mat-files are then post-processed to Netcdf-files by the model runner.
+        This can be used if you have problems compiling SWAN with Netcdf even though Netcdf otherwise works.
+
+        structures given in format:
         E.g. One triangle and one line
         [{'lon': (5,5.1,4.9), 'lat': (60,59.9,59,9), 'trans': 0.3, 'refl': 0.0, 'closed': True, 'name': 'closed triangle'},
         {'lon': (4,4.1), 'lat': (60.1,60.1,60.1),'name': 'breakwater'}
@@ -444,12 +451,16 @@ class SWAN(InputFileWriter):
             file_out.write("$ Generate block-output \n")
             temp_list = forcing_path.split("/")
             forcing_folder = "/".join(temp_list[0:-1])
+
+            extension = ".mat" if write_mat else ".nc"
+            header = "NOHEAD" if write_mat else "HEAD"
+
             file_out.write(
-                "BLOCK 'COMPGRID' HEAD '"
+                f"BLOCK 'COMPGRID' {header} '"
                 + grid.name
                 + "_"
                 + STR_START.split(".")[0]
-                + ".nc"
+                + extension
                 + "' & \n"
             )
             file_out.write(
@@ -465,7 +476,8 @@ class SWAN(InputFileWriter):
                     + grid.name
                     + "_"
                     + STR_START.split(".")[0]
-                    + "_spec.nc"
+                    + "_spec"
+                    + ".nc"
                     + "' & \n"
                 )
                 file_out.write("OUTPUT " + STR_START + " 1 HR \n")

--- a/dnora/executer/post_processors.py
+++ b/dnora/executer/post_processors.py
@@ -4,6 +4,26 @@ from dnora.file_module import FileNames
 import scipy
 import numpy as np
 import xarray as xr
+import geo_parameters as gp
+from geo_skeletons import GriddedSkeleton
+from dnora import msg
+import pathlib
+
+
+SWAN_VARS = {
+    "Hsig": gp.wave.Hs,
+    "Tm01": gp.wave.Tm01,
+    "Tm02": gp.wave.Tm02,
+    "Tm_10": gp.wave.Tm_10,
+    "Depth": gp.ocean.WaterDepth,
+    "Windv_x": gp.wind.XWind,
+    "Windv_y": gp.wind.YWind,
+    "Dspr": gp.wave.Spr,
+    "Dir": gp.wave.Dirm,
+    "TPsmoo": gp.wave.Tp,
+    "RTpeak": gp.wave.Tp,
+    "PkDir": gp.wave.Dirp,
+}
 
 
 class PostProcessor(ABC):
@@ -14,6 +34,69 @@ class PostProcessor(ABC):
     @abstractmethod
     def __str__(self) -> str:
         pass
+
+
+def read_swan_mat_to_ds(filename: str, lon: np.ndarray, lat=np.ndarray) -> xr.Dataset:
+    """Reads a SWAN mat-file and creates an xarray Dataset with standard names"""
+    # This creates a dict with keys
+    # 'Hsig_20200215_000000', 'RTpeak_20200215_000000', 'TPsmoo_20200215_000000' ...
+    mat = scipy.io.loadmat(filename)
+
+    # Create class
+    wave_grid = GriddedSkeleton.add_time()
+    for key, value in SWAN_VARS.items():
+        wave_grid = wave_grid.add_datavar(value(key))
+
+    key = list(SWAN_VARS.keys())[0]
+    keys = [a for a in mat.keys() if key == a.split("_")[0]]
+    keys.sort()
+    start_time = "T".join(keys[0].split("_")[1:])
+    end_time = "T".join(keys[-1].split("_")[1:])
+
+    obj = wave_grid(lon=lon, lat=lat, time=(start_time, end_time))
+
+    for swan_var, param in SWAN_VARS.items():
+
+        keys = [a for a in mat.keys() if swan_var == "_".join(a.split("_")[0:-2])]
+
+        keys.sort()
+        if keys:
+            msg.plain(f"Decoding variable {swan_var} as {param}...")
+        for n, kk in enumerate(keys):
+            obj.ind_insert(
+                swan_var,
+                np.where(np.isnan(mat.get(kk)), np.nan, mat.get(kk)),
+                time=n,
+            )
+
+    return obj.ds()
+
+
+class SwanMatToNc(PostProcessor):
+    def __init__(self, file_names_to_convert: list[str]):
+        self._file_names_to_convert = file_names_to_convert
+
+    def __call__(self, model: ModelRun, file_object: FileNames, **kwargs) -> None:
+
+        lon = model.grid().lon()
+        lat = model.grid().lat()
+
+        for filename in self._file_names_to_convert:
+            filename = pathlib.Path(filename.replace("'", "")).stem
+
+            input_file = f"{file_object.get_folder()}/{filename}.mat"
+            output_file = f"{file_object.get_folder()}/{filename}.nc"
+
+            msg.from_file(input_file)
+            msg.blank()
+            ds = read_swan_mat_to_ds(input_file, lon=lon, lat=lat)
+
+            msg.blank()
+            msg.to_file(output_file)
+            ds.to_netcdf(output_file)
+
+    def __str__(self):
+        return "Converting SWAN output mat-file to NetCDF..."
 
 
 class SwashMatToNc(PostProcessor):

--- a/dnora/executer/post_processors.py
+++ b/dnora/executer/post_processors.py
@@ -65,7 +65,7 @@ def read_swan_mat_to_ds(filename: str, lon: np.ndarray, lat=np.ndarray) -> xr.Da
         for n, kk in enumerate(keys):
             obj.ind_insert(
                 swan_var,
-                np.where(np.isnan(mat.get(kk)), np.nan, mat.get(kk)),
+                np.flipud(np.where(np.isnan(mat.get(kk)), np.nan, mat.get(kk))),
                 time=n,
             )
 

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -407,9 +407,7 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(
-        DnoraDataType.SPECTRA, dnora.read.generic.PointNetcdf(used_for_cache=True)
-    )
+    @cached_reader(DnoraDataType.SPECTRA, dnora.read.generic.PointNetcdf)
     def import_spectra(
         self,
         reader: SpectralDataReader | None = None,
@@ -436,9 +434,7 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(
-        DnoraDataType.SPECTRA1D, dnora.read.generic.PointNetcdf(used_for_cache=True)
-    )
+    @cached_reader(DnoraDataType.SPECTRA1D, dnora.read.generic.PointNetcdf)
     def import_spectra1d(
         self,
         reader: SpectralDataReader | None = None,
@@ -466,9 +462,7 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(
-        DnoraDataType.WAVESERIES, dnora.read.generic.PointNetcdf(used_for_cache=True)
-    )
+    @cached_reader(DnoraDataType.WAVESERIES, dnora.read.generic.PointNetcdf)
     def import_waveseries(
         self,
         reader: PointDataReader | None = None,

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -407,7 +407,9 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(DnoraDataType.SPECTRA, dnora.read.generic.PointNetcdf)
+    @cached_reader(
+        DnoraDataType.SPECTRA, dnora.read.generic.PointNetcdf(used_for_cache=True)
+    )
     def import_spectra(
         self,
         reader: SpectralDataReader | None = None,
@@ -434,7 +436,9 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(DnoraDataType.SPECTRA1D, dnora.read.generic.PointNetcdf)
+    @cached_reader(
+        DnoraDataType.SPECTRA1D, dnora.read.generic.PointNetcdf(used_for_cache=True)
+    )
     def import_spectra1d(
         self,
         reader: SpectralDataReader | None = None,
@@ -462,7 +466,9 @@ class ModelRun:
             **kwargs,
         )
 
-    @cached_reader(DnoraDataType.WAVESERIES, dnora.read.generic.PointNetcdf)
+    @cached_reader(
+        DnoraDataType.WAVESERIES, dnora.read.generic.PointNetcdf(used_for_cache=True)
+    )
     def import_waveseries(
         self,
         reader: PointDataReader | None = None,

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -330,7 +330,9 @@ class ModelRun:
             and not isinstance(point_picker, Trivial)
             and not self.dry_run()
         ):
-            if not utils.grid.data_covers_grid(obj, self.grid()):
+            if not utils.grid.data_covers_grid(obj, self.grid()) and kwargs.get(
+                "coverage_warning", True
+            ):
                 msg.warning(
                     f"The imported data (lon: {obj.edges('lon')}, lat: {obj.edges('lat')}) does not cover the grid (lon: {self.grid().edges('lon')}, lat: {self.grid().edges('lat')})! Maybe increase the expansion_factor (now {expansion_factor}) in the import method?"
                 )

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -108,7 +108,15 @@ def start_and_end_time_of_run(
 
 
 class ModelRun:
-    _reader_dict: dict[DnoraDataType:ReaderFunction] = {}
+    _reader_dict: dict[DnoraDataType:ReaderFunction] = {
+        DnoraDataType.SPECTRA: dnora.read.generic.PointNetcdf(),
+        DnoraDataType.SPECTRA1D: dnora.read.generic.PointNetcdf(),
+        DnoraDataType.WAVESERIES: dnora.read.generic.PointNetcdf(),
+        DnoraDataType.WIND: dnora.read.generic.Netcdf(),
+        DnoraDataType.ICE: dnora.read.generic.Netcdf(),
+        DnoraDataType.CURRENT: dnora.read.generic.Netcdf(),
+        DnoraDataType.WATERLEVEL: dnora.read.generic.Netcdf(),
+    }
     _point_picker: PointPicker = NearestGridPoint()
 
     def __init__(

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -662,17 +662,18 @@ class ModelRun:
         freq: np.ndarray | None = None,
         dirs: np.ndarray | None = None,
         freq0: float = 0.04118,
-        nfreq: int | None = None,
+        nfreq: int = 32,
         ndir: int = 36,
         finc: float = 1.1,
         dirshift: float | None = None,
+        extend_spectra: bool = False,
     ):
         """Sets spectral grid for model run. Will be used to write input files."""
         if freq is None:
             freq = np.array([freq0 * finc**n for n in np.linspace(0, nfreq - 1, nfreq)])
         if nfreq is None:
             nfreq = len(freq)
-        if len(freq) < nfreq:
+        if len(freq) < nfreq and extend_spectra:
             start_freq = freq[-1]
             add_freq = np.array(
                 [

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -609,7 +609,8 @@ class ModelRun:
 
         if self.waveseries() is not None:
             dirp = self.waveseries().dirp(squeeze=False)
-
+        if self.spectral_grid() is None:
+            raise ValueError("Define a spectral grid with .set_spectral_grid()")
         spectral_reader = Spectra1DToSpectra(
             self.spectra1d(), self.spectral_grid().dirs(), dirp=dirp
         )
@@ -629,6 +630,9 @@ class ModelRun:
         if self.waveseries() is None:
             msg.warning("No Waveseries to convert to Spectra!")
             return
+
+        if self.spectral_grid() is None:
+            raise ValueError("Define a spectral grid with .set_spectral_grid()")
 
         spectral_reader = WaveSeriesToJONSWAP1D(
             self.waveseries(), self.spectral_grid().freq()

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -18,7 +18,7 @@ from dnora.modelrun.import_functions import import_data
 from dnora.type_manager.model_formats import ModelFormat
 from dnora.spectral_grid import SpectralGrid
 
-
+import dnplot
 from dnora import msg
 from dnora.cacher.cache_decorator import cached_reader
 
@@ -141,6 +141,8 @@ class ModelRun:
         self._reference_time = None
         self.name = name
         self._post_processing = None
+
+        self.plot = dnplot.Matplotlib(self)
         self._dnora_objects: dict[DnoraDataType, DnoraObject] = {
             DnoraDataType.GRID: grid,
         }

--- a/dnora/read/generic/generic_readers.py
+++ b/dnora/read/generic/generic_readers.py
@@ -190,20 +190,19 @@ class Netcdf(DataReader):
         )
 
         cls = dnora_objects.get(obj_type)
-
-        if "time" in cls.core.coords():
-            ds = xr.open_mfdataset(filepath).sel(
-                lon=slice(*lon), lat=slice(*lat), time=slice(start_time, end_time)
-            )
-        else:
-            ds = xr.open_mfdataset(filepath).sel(lon=slice(*lon), lat=slice(*lat))
-
         msg.from_multifile(filepath)
-
+        ds = xr.open_mfdataset(filepath)
         # This geo-skeleton method does all the heavy lifting with decoding the Dataset to match the class data variables etc.
         data = cls.from_ds(ds)
 
-        return data.ds()
+        if "time" in cls.core.coords():
+            ds = data.ds().sel(time=slice(start_time, end_time))
+        if lon[0] == lon[1] and lat[0] == lat[1]:
+            msg.plain("Reading full file when no area defined...")
+        else:
+            ds = data.ds().sel(lon=slice(*lon), lat=slice(*lat))
+
+        return ds
 
 
 # class Netcdf(DataReader):

--- a/dnora/read/generic/generic_readers.py
+++ b/dnora/read/generic/generic_readers.py
@@ -161,7 +161,7 @@ class Netcdf(DataReader):
     def caching_strategy() -> CachingStrategy:
         return CachingStrategy.DontCacheMe
 
-    def __init__(self, files: list[str] = None):
+    def __init__(self, files: list[str] = None, **kwargs):
         self.files = files
 
     def __call__(

--- a/dnora/read/generic/generic_readers.py
+++ b/dnora/read/generic/generic_readers.py
@@ -179,10 +179,7 @@ class Netcdf(DataReader):
 
         filename = filename or self.files
 
-        if filename is None:
-            raise ValueError("Provide at least one filename!")
-        filepath = get_url(folder, filename, get_list=True)
-        filepath = [file for file in filepath if os.path.getsize(file) > 0]
+        filepath = create_filelist(filename, folder)
 
         msg.process(f"Using expansion_factor = {expansion_factor:.2f}")
         lon, lat = utils.grid.expand_area(

--- a/dnora/utils/spec.py
+++ b/dnora/utils/spec.py
@@ -29,6 +29,8 @@ def directional_distribution(freq, fp, dirs, dirp):
 
     mask = dirs > 180
     dirs[mask] = dirs[mask] - 360
+    mask = dirs < -180
+    dirs[mask] = dirs[mask] + 360
 
     theta = np.deg2rad(dirs)
 
@@ -36,7 +38,6 @@ def directional_distribution(freq, fp, dirs, dirp):
 
     for n in range(len(freq)):
         D[n, :] = A2[n] * np.cos(0.5 * theta) ** (2 * s[n])
-
     return D
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - geo-skeletons=0.20.4
   - pip
   - pip:
-    - dnplot==0.3.1
+    - dnplot
   - pytest
   - pytest-cov
   - cdsapi>=0.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - xarray>=0.20.1
   - meshio
   - scipy
-  - geo-skeletons=0.20.4
+  - geo-skeletons>=0.20.4
   - pip
   - pip:
     - dnplot

--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,3 @@ dependencies:
   - matplotlib
   - cmocean
   - copernicusmarine
-  - pyarrow

--- a/tests/test_bnd_process.py
+++ b/tests/test_bnd_process.py
@@ -35,6 +35,7 @@ def loop_conventions(list_of_conventions, S, D):
     Snew = copy(S)
     inds = np.array(range(S.shape[0]))
     Dnew = copy(D)
+    freq = np.linspace(0.0345, 0.5476, 30) 
     for n in range(len(list_of_conventions) - 1):
         cur_c = list_of_conventions[n]
         wan_c = list_of_conventions[n + 1]
@@ -43,10 +44,10 @@ def loop_conventions(list_of_conventions, S, D):
         )
         if not isinstance(bnd_processor, list):
             bnd_processor = [bnd_processor]
-
+        
         for processor in bnd_processor:
             Snew, Dnew, _, _, _ = processor(
-                spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
             )
     return Snew, Dnew
 
@@ -56,6 +57,8 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
         for dD in [1.0, 2.0, 3.0, 5.0, 6.0, 9.0, 10.0, 15.0, 18.0, 22.5, 30.0, 45.0]:
             D = np.arange(0, 360, dD)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             inds = np.array(range(S.shape[0]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
@@ -64,9 +67,9 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.mod(np.arange(0, 36, dD / 10) + 18, 36)
             self.assertIsNone(
@@ -78,17 +81,19 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
             D = np.arange(0, 360, dD)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.OCEAN,
                     wanted_convention=SpectralConvention.WW3,
                 )
             )
+            
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(
                     Dnew, np.mod(np.arange(0, -360, -dD) + 90, 360)
@@ -104,7 +109,8 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
             D = np.arange(0, 360, dD)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.OCEAN,
@@ -112,9 +118,9 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.mod(np.arange(0, -36, -dD / 10) + 9, 36)
             self.assertIsNone(
@@ -126,7 +132,8 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
             D = np.arange(0, 360, dD)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.OCEAN,
@@ -134,7 +141,7 @@ class BoundarySpectralConventionsOcean(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
 
             self.assertIsNone(
@@ -156,7 +163,8 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.WW3,
@@ -164,9 +172,9 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(Dnew, np.arange(0, 360, dD))
             )
@@ -187,7 +195,8 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.WW3,
@@ -198,9 +207,9 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(Dnew, np.arange(0, 360, dD))
             )
@@ -219,7 +228,8 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.WW3,
@@ -233,9 +243,9 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(Dnew, np.arange(0, 360, dD))
             )
@@ -254,7 +264,8 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.WW3,
@@ -269,9 +280,9 @@ class BoundarySpectralConventionsWW3(unittest.TestCase):
 
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             self.assertIsNone(
                 np.testing.assert_almost_equal(
@@ -292,7 +303,8 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MET,
@@ -300,9 +312,9 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.arange(0, 36, dD / 10)
             self.assertIsNone(
@@ -319,7 +331,8 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MET,
@@ -331,9 +344,9 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
 
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(
                     Dnew, np.mod(np.arange(0, -360, -dD) + 90, 360)
@@ -354,7 +367,8 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MET,
@@ -366,9 +380,9 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
 
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.mod(np.arange(0, -36, -dD / 10) + 9, 36)
             self.assertIsNone(
@@ -385,7 +399,8 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MET,
@@ -397,9 +412,9 @@ class BoundarySpectralConventionsMet(unittest.TestCase):
 
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(
                     Dnew, np.mod(np.arange(0, -360, -dD) + 90, 360)
@@ -424,7 +439,8 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATH,
@@ -433,9 +449,9 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
             )
 
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.arange(0, 36, dD / 10)
             mask = stemp > 35.999
@@ -452,7 +468,8 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATH,
@@ -464,9 +481,8 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
             self.assertIsNone(
                 np.testing.assert_almost_equal(
                     Dnew, np.mod(np.arange(0, -360, -dD) + 90, 360)
@@ -484,7 +500,8 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATH,
@@ -496,9 +513,9 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.mod(np.arange(0, 36, dD / 10) + 18, 36)
             self.assertIsNone(np.testing.assert_almost_equal(Snew, [stemp, stemp]))
@@ -513,7 +530,8 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
                 ]
             )
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATH,
@@ -525,9 +543,9 @@ class BoundarySpectralConventionsMath(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(
                     Dnew, np.mod(np.arange(0, -360, -dD) + 90, 360)
@@ -545,7 +563,8 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             D = np.mod(np.arange(0, -360, -dD) + 90, 360)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATHVEC,
@@ -553,7 +572,7 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
                 )
             )
             Snew, Dnew, _, _, _ = bnd_processor(
-                spec=S, dirs=D, freq=np.array([[0.1]]), inds=inds, times=None
+                spec=S, dirs=D, freq=freq, inds=inds, times=None
             )
 
             self.assertIsNone(
@@ -566,7 +585,8 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             D = np.mod(np.arange(0, -360, -dD) + 90, 360)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATHVEC,
@@ -578,9 +598,9 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(Dnew, np.arange(0, 360, dD))
             )
@@ -594,7 +614,8 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             D = np.mod(np.arange(0, -360, -dD) + 90, 360)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATHVEC,
@@ -606,9 +627,9 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(np.testing.assert_almost_equal(Dnew, D))
             stemp = np.mod(np.arange(0, -36, -dD / 10) + 9, 36)
             mask = stemp > 35.999
@@ -620,7 +641,8 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             D = np.mod(np.arange(0, -360, -dD) + 90, 360)
             S = np.array([np.arange(0, 36, dD / 10), np.arange(0, 36, dD / 10)])
             inds = np.array(range(S.shape[0]))
-
+            freq = np.array([[0.1]])
+            S = np.reshape(S, (S.shape[0],len(freq),S.shape[-1]))
             bnd_processor = (
                 dnora.process.spectra.spectral_processor_for_convention_change(
                     current_convention=SpectralConvention.MATHVEC,
@@ -632,9 +654,9 @@ class BoundarySpectralConventionsMathVec(unittest.TestCase):
             Dnew = copy(D)
             for processor in bnd_processor:
                 Snew, Dnew, _, _, _ = processor(
-                    spec=Snew, dirs=Dnew, freq=np.array([[0.1]]), inds=inds, times=None
+                    spec=Snew, dirs=Dnew, freq=freq, inds=inds, times=None
                 )
-
+            Snew = np.squeeze(Snew)
             self.assertIsNone(
                 np.testing.assert_almost_equal(Dnew, np.arange(0, 360, dD))
             )


### PR DESCRIPTION
If you give write_mat=True when writing the input file, then SWAN will save a mat-file instead of a netcdf file for the gridded variables. A post-processor will be activated to convert taht mat-file to a netcdf file after the model run.

This option was included because sometimes there are issues with compiling SWAN with the correct netcdf support.