### PR TITLE
Nesting possibilities

### DIFF
--- a/dnora/executer/decorators.py
+++ b/dnora/executer/decorators.py
@@ -5,16 +5,21 @@ def add_write_method(file_type: DnoraFileType):
     def wrapper(c):
         def write(self, **kwargs) -> None:
             self._write(file_type=file_type, **kwargs)
+            if self._nest is not None:
+                self._nest._write(file_type=file_type, **kwargs)
 
         exec(f"c.write_{file_type.name.lower()}_file = write")
         return c
 
     return wrapper
 
+
 def add_run_method(file_type: DnoraFileType):
     def wrapper(c):
         def run(self, **kwargs) -> None:
             self._run(file_type=file_type, **kwargs)
+            if self._nest is not None:
+                self._nest._run(file_type=file_type, **kwargs)
 
         exec(f"c.run_{file_type.name.lower()} = run")
         return c

--- a/dnora/executer/decorators.py
+++ b/dnora/executer/decorators.py
@@ -5,8 +5,11 @@ def add_write_method(file_type: DnoraFileType):
     def wrapper(c):
         def write(self, **kwargs) -> None:
             self._write(file_type=file_type, **kwargs)
-            if self._nest is not None:
-                self._nest._write(file_type=file_type, **kwargs)
+            nest = self._nest
+
+            while nest is not None:
+                nest._write(file_type=file_type, **kwargs)
+                nest = nest._nest
 
         exec(f"c.write_{file_type.name.lower()}_file = write")
         return c
@@ -18,8 +21,11 @@ def add_run_method(file_type: DnoraFileType):
     def wrapper(c):
         def run(self, **kwargs) -> None:
             self._run(file_type=file_type, **kwargs)
-            if self._nest is not None:
-                self._nest._run(file_type=file_type, **kwargs)
+            nest = self._nest
+
+            while nest is not None:
+                nest._run(file_type=file_type, **kwargs)
+                nest = nest._nest
 
         exec(f"c.run_{file_type.name.lower()} = run")
         return c

--- a/dnora/executer/executer.py
+++ b/dnora/executer/executer.py
@@ -127,8 +127,10 @@ class ModelExecuter:
             **kwargs,
         )
 
-        if self._nest is not None:
-            self._nest._run(
+        nest = self._nest
+
+        while nest is not None:
+            nest._run(
                 file_type=DnoraFileType.INPUT,
                 model_runner=model_runner,
                 model_folder=model_folder,
@@ -136,6 +138,7 @@ class ModelExecuter:
                 dry_run=dry_run,
                 **kwargs,
             )
+            nest = nest._nest
 
     def _run(
         self,

--- a/dnora/executer/executer.py
+++ b/dnora/executer/executer.py
@@ -12,6 +12,7 @@ from .decorators import add_write_method, add_run_method
 from dnora.defaults import read_environment_variable
 from typing import Union, Optional
 
+
 @add_run_method(DnoraFileType.SPECTRA)
 @add_run_method(DnoraFileType.ICE)
 @add_run_method(DnoraFileType.WATERLEVEL)
@@ -35,8 +36,12 @@ class ModelExecuter:
     def _get_default_format(self) -> str:
         return ModelFormat.MODELRUN
 
-    def __init__(self, model):
+    def __init__(self, model, include_nest: bool = True):
         self.model = model
+        if include_nest and model.nest() is not None:
+            self._nest = self.__class__(model.nest())
+        else:
+            self._nest = None
 
     def dry_run(self) -> bool:
         return self._dry_run or self.model.dry_run()
@@ -109,7 +114,7 @@ class ModelExecuter:
         model_runner: Optional[ModelRunner] = None,
         model_folder: str = "",
         post_process: bool = True,
-        dry_run: bool = False, 
+        dry_run: bool = False,
         **kwargs,
     ):
         """Run the main model. Set post_process=False to disable any post-processing that might be defined."""
@@ -121,6 +126,16 @@ class ModelExecuter:
             dry_run=dry_run,
             **kwargs,
         )
+
+        if self._nest is not None:
+            self._nest._run(
+                file_type=DnoraFileType.INPUT,
+                model_runner=model_runner,
+                model_folder=model_folder,
+                post_process=post_process,
+                dry_run=dry_run,
+                **kwargs,
+            )
 
     def _run(
         self,

--- a/dnora/executer/inputfile/inputfile_writers.py
+++ b/dnora/executer/inputfile/inputfile_writers.py
@@ -311,6 +311,8 @@ class SWAN(InputFileWriter):
                 ice_object, ice_file = recuresively_find_parent_object_and_filename(
                     model, DnoraDataType.ICE
                 )
+                if not isinstance(ice_file, list):
+                    ice_file = [ice_file]
                 swan_ice(
                     file_out,
                     ice_object,

--- a/dnora/executer/inputfile/inputfile_writers.py
+++ b/dnora/executer/inputfile/inputfile_writers.py
@@ -210,8 +210,6 @@ class SWAN(InputFileWriter):
                         model.parent().input_file_exported_to(DnoraFileType.INPUT)[-1]
                     ).parent
                 )
-
-            if model.parent() is not None:
                 nest_file = str(Path(parent_folder).resolve())
                 file_out.write(f"BOUN NEST &\n'{nest_file}/bspec.asc' &\nOPEN\n")
 
@@ -264,37 +262,53 @@ class SWAN(InputFileWriter):
                 file_out.write(f"WIND {ff:.2f} {dd:.0f}\n")
 
             if use_waterlevel and not homog:
-                if model.waterlevel() is not None:
+                waterlevel_object, waterlevel_file = (
+                    recuresively_find_parent_object_and_filename(
+                        model, DnoraDataType.WATERLEVEL
+                    )
+                )
+                if waterlevel_object is not None:
                     self.output_var.append("WATLEV")
+
                 swan_waterlevel(
                     file_out,
-                    model.waterlevel(),
+                    waterlevel_object,
                     STR_START,
                     STR_END,
                     factor["waterlevel"],
-                    exported_files["waterlevel"][-1],
+                    waterlevel_file,
                 )
 
             if use_current and not homog:
-                if model.current() is not None:
+                current_object, current_file = (
+                    recuresively_find_parent_object_and_filename(
+                        model, DnoraDataType.CURRENT
+                    )
+                )
+
+                if current_object is not None:
                     self.output_var.append("VEL")
+
                 swan_current(
                     file_out,
-                    model.current(),
+                    current_object,
                     STR_START,
                     STR_END,
                     factor["current"],
-                    exported_files["current"][-1],
+                    current_file,
                 )
 
             if use_ice and not homog:
+                ice_object, ice_file = recuresively_find_parent_object_and_filename(
+                    model, DnoraDataType.ICE
+                )
                 swan_ice(
                     file_out,
-                    model.ice(),
+                    ice_object,
                     STR_START,
                     STR_END,
                     factor["ice"],
-                    exported_files["ice"],
+                    ice_file,
                 )
 
             HOTSTART_FILE = (

--- a/dnora/executer/inputfile/inputfile_writers.py
+++ b/dnora/executer/inputfile/inputfile_writers.py
@@ -212,14 +212,23 @@ class SWAN(InputFileWriter):
                 )
                 nest_file = str(Path(parent_folder).resolve())
                 file_out.write(f"BOUN NEST &\n'{nest_file}/bspec.asc' &\nOPEN\n")
+                msg.plain(
+                    f"Adding boundary spectra to SWAN input file: {nest_file}/bspec.asc"
+                )
 
             if use_spectra and not homog:
-                swan_spectra(
-                    file_out,
-                    model.grid(),
-                    model.spectra(),
-                    exported_files["spectra"][-1],
+                spectral_object, spectral_file = (
+                    recuresively_find_parent_object_and_filename(
+                        model, DnoraDataType.SPECTRA
+                    )
                 )
+                if model.spectra() is not None:
+                    swan_spectra(
+                        file_out,
+                        model.grid(),
+                        spectral_object,
+                        spectral_file,
+                    )
             elif homog.get("spectra") is not None:
                 swan_homog_spectra(
                     file_out,

--- a/dnora/executer/inputfile/swan_functions.py
+++ b/dnora/executer/inputfile/swan_functions.py
@@ -44,6 +44,11 @@ def creat_swan_input_grid_string(grid) -> str:
     return input_grid_string
 
 
+def swan_output_for_nest(file_out, nested_grid) -> None:
+    file_out.write(f"NGRID 'bspec' {create_swan_grid_string(nested_grid)}\n")
+    file_out.write(f"NESTout 'bspec' 'bspec.asc'\n")
+
+
 def swan_header(file_out, grid_name: str) -> None:
     """Writes header information to SWAN input file"""
     file_out.write("$************************HEADING************************\n")
@@ -70,7 +75,7 @@ def swan_grid(
     file_out.write("$ \n")
 
     file_out.write("INPGRID BOTTOM " + creat_swan_input_grid_string(grid) + "\n")
-    file_out.write("READINP BOTTOM 1 '" + grid_path.split("/")[-1] + "' 3 0 FREE \n")
+    file_out.write("READINP BOTTOM 1 '" + grid_path.split("/")[-1] + "'&\n 3 0 FREE \n")
     file_out.write("$ \n")
 
 
@@ -91,7 +96,7 @@ def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
 
     for lon, lat in zip(lons, lats):
         bound_string += f" {lon:.4f} {lat:.4f}"
-    bound_string += " VARIABLE FILE 0 "
+    bound_string += " VARIABLE FILE 0 &\n"
     bound_string += f"'{boundary_path.split('/')[-1]}'\n"
     file_out.write(bound_string)
 
@@ -165,13 +170,8 @@ def swan_wind(
         + STR_END
         + "\n"
     )
-
     file_out.write(
-        "READINP WIND "
-        + str(factor)
-        + "  '"
-        + forcing_path.split("/")[-1]
-        + "' 3 0 0 1 FREE \n"
+        "READINP WIND " + str(factor) + "  &\n'" + forcing_path + "' &\n3 0 0 1 FREE \n"
     )
     file_out.write("$ \n")
 

--- a/dnora/executer/inputfile/swan_functions.py
+++ b/dnora/executer/inputfile/swan_functions.py
@@ -1,7 +1,12 @@
 import numpy as np
-from dnora.utils.grid import identify_boundary_edges
+from dnora.utils.grid import (
+    identify_boundary_edges,
+    create_ordered_boundary_list,
+    get_coords_for_boundary_edges,
+)
 
 from dnora import msg
+
 
 def create_swan_segment_coords(boundary_mask, lon_edges, lat_edges):
     """Createsa longitude and latitude arrays for the SWAN BOUND SEGEMENT
@@ -68,14 +73,6 @@ def swan_grid(
     file_out.write("READINP BOTTOM 1 '" + grid_path.split("/")[-1] + "' 3 0 FREE \n")
     file_out.write("$ \n")
 
-
-    if current is None:
-        msg.info(
-            "No current object provided. OceanCurrent information will NOT be written to SWAN input file!"
-        )
-        return
-
-    delta_Xf = np.round(np.diff(current.edges("lon")), 5)[0]
 
 def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
     """Writes information about boundary spectra to SWAN input file"""
@@ -169,14 +166,6 @@ def swan_wind(
         + "\n"
     )
 
-
-    if current is None:
-        msg.info(
-            "No current object provided. OceanCurrent information will NOT be written to SWAN input file!"
-        )
-        return
-
-    delta_Xf = np.round(np.diff(current.edges("lon")), 5)[0]
     file_out.write(
         "READINP WIND "
         + str(factor)
@@ -272,8 +261,7 @@ def swan_current(
         + "' 3 0 0 1 FREE \n"
     )
     file_out.write("$ \n")
-    delta_X = np.round(np.diff(grid.edges("lon")), 5)[0]
-    delta_Y = np.round(np.diff(grid.edges("lat")), 5)[0]
+
 
 def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) -> None:
     """Writes ice information to SWAN input file"""
@@ -291,14 +279,6 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
             -1
         ].startswith("ice"):
             ICE_NAME = "AICE"
-
-    if current is None:
-        msg.info(
-            "No current object provided. OceanCurrent information will NOT be written to SWAN input file!"
-        )
-        return
-
-    delta_Xf = np.round(np.diff(current.edges("lon")), 5)[0]
         elif ice_path[i].split("/")[-1].startswith("sit"):
             ICE_NAME = "HICE"
         # self.output_var = self.output_var + " " + ICE_NAME # comment due to AICE/HICE not available as output in nc-format in SWAN
@@ -325,11 +305,6 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
         )
         file_out.write(
             "READINP "
-        + " "
-        + str((delta_Xf / (waterlevel.nx() - 1)).round(6))
-        + " "
-        + str((delta_Yf / (waterlevel.ny() - 1)).round(6))
-        + " NONSTATIONARY "
             + ICE_NAME
             + " "
             + str(factor)

--- a/dnora/executer/inputfile/swan_functions.py
+++ b/dnora/executer/inputfile/swan_functions.py
@@ -83,10 +83,8 @@ def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
     """Writes information about boundary spectra to SWAN input file"""
 
     if spectra is None:
-        msg.info(
-            "No spectra object provided. Spectra information will NOT be written to SWAN input file!"
-        )
         return
+    msg.plain("Adding boundary spectra to SWAN input file")
 
     lons, lats = create_swan_segment_coords(
         grid.boundary_mask(), grid.edges("lon"), grid.edges("lat")
@@ -106,6 +104,7 @@ def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
 def swan_homog_spectra(file_out, grid, homog: dict) -> None:
     """Writes stationary boundary conditions to SWAN input file"""
     gamma = homog.get("gamma", 3.3)
+    msg.plain("Adding constant JONSWAP boundary to SWAN input file")
     file_out.write(f"BOUND SHAP JON {gamma} PEAK DSPR POWER\n")
     for side in identify_boundary_edges(grid.boundary_mask()):
         boundary = homog.get(side)
@@ -143,10 +142,8 @@ def swan_wind(
     """Writes wind information to SWAN input file"""
 
     if forcing is None:
-        msg.info(
-            "No wind object provided. Wind information will NOT be written to SWAN input file!"
-        )
         return
+    msg.plain("Adding wind forcing to SWAN input file")
 
     delta_Xf = np.round(np.diff(forcing.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(forcing.edges("lat")), 5)[0]
@@ -181,10 +178,8 @@ def swan_waterlevel(
 ) -> None:
     """Writes waterlevel information to SWAN input file"""
     if waterlevel is None:
-        msg.info(
-            "No waterlevel object provided. Waterlevel information will NOT be written to SWAN input file!"
-        )
         return
+    msg.plain("Adding waterlevel forcing to SWAN input file")
 
     delta_Xf = np.round(np.diff(waterlevel.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(waterlevel.edges("lat")), 5)[0]
@@ -225,10 +220,9 @@ def swan_current(
     """Writes current information to SWAN input file"""
 
     if current is None:
-        msg.info(
-            "No current object provided. OceanCurrent information will NOT be written to SWAN input file!"
-        )
         return
+
+    msg.plain("Adding current forcing to SWAN input file")
 
     delta_Xf = np.round(np.diff(current.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(current.edges("lat")), 5)[0]
@@ -267,10 +261,8 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
     """Writes ice information to SWAN input file"""
 
     if ice is None:
-        msg.info(
-            "No ice object provided. Ice information will NOT be written to SWAN input file!"
-        )
         return
+    msg.plain("Adding iceforcing to SWAN input file")
 
     delta_Xf = np.round(np.diff(ice.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(ice.edges("lat")), 5)[0]
@@ -321,6 +313,7 @@ def swan_structures(file_out, structures: list[dict]) -> None:
     closed = False
     if structures:
         file_out.write("$ Define obstacles (structures) \n")
+        msg.plain("Adding list of structtures to SWAN input file")
     for structure in structures:
         trans = structure.get("trans", trans)
         if trans is None:
@@ -351,6 +344,7 @@ def swan_spectral_output_points(file_out, grid, STR_START: str, homog: bool) -> 
     spec_lon, spec_lat = grid.output_points()
     if len(spec_lon) == 0:
         return
+    msg.plain("Listing spectral output points to SWAN input file")
     file_out.write("$ Generate spectral output \n")
     file_out.write("POINTS 'pkt' &\n")
     for slon, slat in zip(spec_lon, spec_lat):

--- a/dnora/executer/inputfile/swan_functions.py
+++ b/dnora/executer/inputfile/swan_functions.py
@@ -6,6 +6,7 @@ from dnora.utils.grid import (
 )
 
 from dnora import msg
+from pathlib import Path
 
 
 def create_swan_segment_coords(boundary_mask, lon_edges, lat_edges):
@@ -259,12 +260,11 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
     delta_Xf = np.round(np.diff(ice.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(ice.edges("lat")), 5)[0]
     for i in range(len(ice_path)):
-        if ice_path[i].split("/")[-1].startswith("sic") or ice_path[i].split("/")[
-            -1
-        ].startswith("ice"):
+        if str(Path(ice_path[i]).stem).startswith("ice"):
             ICE_NAME = "AICE"
-        elif ice_path[i].split("/")[-1].startswith("sit"):
+        elif str(Path(ice_path[i]).stem).startswith("sit"):
             ICE_NAME = "HICE"
+
         # self.output_var = self.output_var + " " + ICE_NAME # comment due to AICE/HICE not available as output in nc-format in SWAN
         file_out.write(
             "INPGRID "

--- a/dnora/executer/inputfile/swan_functions.py
+++ b/dnora/executer/inputfile/swan_functions.py
@@ -84,7 +84,7 @@ def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
 
     if spectra is None:
         return
-    msg.plain("Adding boundary spectra to SWAN input file")
+    msg.plain(f"Adding boundary spectra to SWAN input file: {boundary_path}")
 
     lons, lats = create_swan_segment_coords(
         grid.boundary_mask(), grid.edges("lon"), grid.edges("lat")
@@ -95,7 +95,7 @@ def swan_spectra(file_out, grid, spectra, boundary_path: str) -> None:
     for lon, lat in zip(lons, lats):
         bound_string += f" {lon:.4f} {lat:.4f}"
     bound_string += " VARIABLE FILE 0 &\n"
-    bound_string += f"'{boundary_path.split('/')[-1]}'\n"
+    bound_string += f"'{boundary_path}'\n"
     file_out.write(bound_string)
 
     file_out.write("$ \n")
@@ -143,7 +143,7 @@ def swan_wind(
 
     if forcing is None:
         return
-    msg.plain("Adding wind forcing to SWAN input file")
+    msg.plain(f"Adding wind forcing to SWAN input file: {forcing_path}")
 
     delta_Xf = np.round(np.diff(forcing.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(forcing.edges("lat")), 5)[0]
@@ -179,7 +179,7 @@ def swan_waterlevel(
     """Writes waterlevel information to SWAN input file"""
     if waterlevel is None:
         return
-    msg.plain("Adding waterlevel forcing to SWAN input file")
+    msg.plain(f"Adding waterlevel forcing to SWAN input file: {waterlevel_path}")
 
     delta_Xf = np.round(np.diff(waterlevel.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(waterlevel.edges("lat")), 5)[0]
@@ -205,11 +205,7 @@ def swan_waterlevel(
     )
 
     file_out.write(
-        "READINP WLEV "
-        + str(factor)
-        + "  '"
-        + waterlevel_path.split("/")[-1]
-        + "' 3 0 1 FREE \n"
+        "READINP WLEV " + str(factor) + "  '" + waterlevel_path + "' 3 0 1 FREE \n"
     )
     file_out.write("$ \n")
 
@@ -222,7 +218,7 @@ def swan_current(
     if current is None:
         return
 
-    msg.plain("Adding current forcing to SWAN input file")
+    msg.plain(f"Adding current forcing to SWAN input file: {current_path}")
 
     delta_Xf = np.round(np.diff(current.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(current.edges("lat")), 5)[0]
@@ -248,11 +244,7 @@ def swan_current(
     )
 
     file_out.write(
-        "READINP CUR "
-        + str(factor)
-        + "  '"
-        + current_path.split("/")[-1]
-        + "' 3 0 0 1 FREE \n"
+        "READINP CUR " + str(factor) + "  '" + current_path + "' 3 0 0 1 FREE \n"
     )
     file_out.write("$ \n")
 
@@ -262,7 +254,7 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
 
     if ice is None:
         return
-    msg.plain("Adding iceforcing to SWAN input file")
+    msg.plain(f"Adding iceforcing to SWAN input file: {ice_path}")
 
     delta_Xf = np.round(np.diff(ice.edges("lon")), 5)[0]
     delta_Yf = np.round(np.diff(ice.edges("lat")), 5)[0]
@@ -296,13 +288,7 @@ def swan_ice(file_out, ice, STR_START, STR_END, factor: float, ice_path: str) ->
             + " \n"
         )
         file_out.write(
-            "READINP "
-            + ICE_NAME
-            + " "
-            + str(factor)
-            + "  '"
-            + ice_path[i].split("/")[-1]
-            + "' \n"
+            "READINP " + ICE_NAME + " " + str(factor) + "  '" + ice_path[i] + "' \n"
         )
         file_out.write("$ \n")
 

--- a/dnora/export/decorators.py
+++ b/dnora/export/decorators.py
@@ -5,8 +5,12 @@ def add_export_method(obj_type: DnoraDataType):
     def wrapper(c):
         def export(self, *args, **kwargs) -> None:
             self.export(obj_type, *args, **kwargs)
-            if self._nest is not None:
-                self._nest.export(obj_type, *args, **kwargs)
+
+            nest = self._nest
+
+            while nest is not None:
+                nest.export(obj_type, *args, **kwargs)
+                nest = nest._nest
 
         exec(f"c.export_{obj_type.name.lower()} = export")
         return c

--- a/dnora/export/decorators.py
+++ b/dnora/export/decorators.py
@@ -5,6 +5,8 @@ def add_export_method(obj_type: DnoraDataType):
     def wrapper(c):
         def export(self, *args, **kwargs) -> None:
             self.export(obj_type, *args, **kwargs)
+            if self._nest is not None:
+                self._nest.export(obj_type, *args, **kwargs)
 
         exec(f"c.export_{obj_type.name.lower()} = export")
         return c

--- a/dnora/export/exporter.py
+++ b/dnora/export/exporter.py
@@ -53,6 +53,9 @@ class DataExporter:
     def __init__(self, model, include_nest: bool = True):
         self.model = model
         if include_nest and model.nest() is not None:
+            msg.process(
+                f"Including nested grid {model.nest().grid().name} inside {model.grid().name}"
+            )
             self._nest = self.__class__(model.nest())
         else:
             self._nest = None

--- a/dnora/export/exporter.py
+++ b/dnora/export/exporter.py
@@ -41,15 +41,21 @@ class DataExporter:
     def _get_default_format(self) -> str:
         return ModelFormat.MODELRUN
 
-    def _get_writer(self, obj_type: Union[DnoraDataType, DnoraFileType]) -> WriterFunction:
+    def _get_writer(
+        self, obj_type: Union[DnoraDataType, DnoraFileType]
+    ) -> WriterFunction:
         return self._writer_dict.get(obj_type, self._get_default_writer())
 
     # def _get_spectral_convention(self) -> SpectralConvention:
     #     """Used only if method is not defined, such as for GeneralWritingFunctions that just dump everything to montly netcdf-files."""
     #     return SpectralConvention.OCEAN
 
-    def __init__(self, model):
+    def __init__(self, model, include_nest: bool = True):
         self.model = model
+        if include_nest and model.nest() is not None:
+            self._nest = self.__class__(model.nest())
+        else:
+            self._nest = None
 
     def export(
         self,
@@ -68,14 +74,19 @@ class DataExporter:
         writer_function = self._setup_export(obj_type, writer, dry_run)
 
         if not self.dry_run():
+            if not self._silent:
+                if self.model.get(obj_type) is not None:
+                    data_name = f" from {self.model[obj_type].name}"
+                else:
+                    data_name = ""
+                msg.header(
+                    writer_function,
+                    f"Writing {obj_type.name} data" + data_name,
+                )
+
             if self.model.get(obj_type) is None:
                 msg.info(f"No {obj_type.name} data exists. Won't export anything.")
                 return
-            if not self._silent:
-                msg.header(
-                    writer_function,
-                    f"Writing {obj_type.name} data from {self.model[obj_type].name}",
-                )
 
             if spectral_convention is None:
                 try:  # GeneralWritingFunction might not have this method defined

--- a/dnora/modelrun/import_functions.py
+++ b/dnora/modelrun/import_functions.py
@@ -114,8 +114,8 @@ def read_data_and_create_object(
         **kwargs,
     )
     if ds is None:
-        raise ValueError('No data found!')
-        
+        raise ValueError("No data found!")
+
     if not isinstance(ds, tuple):
         obj = dnora_class.from_ds(
             ds, dynamic=False

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from dnora.read.abstract_readers import ReaderFunction
 from dnora.type_manager.dnora_objects import dnora_objects
 
+
 def start_and_end_time_of_run(
     start_time: Optional[str],
     end_time: Optional[str],
@@ -146,6 +147,7 @@ class ModelRun:
         self._reference_time = None
         self.name = name
         self._post_processing = None
+        self._nest = None
 
         self.plot = dnplot.Matplotlib(self)
         self._dnora_objects: dict[DnoraDataType, DnoraObject] = {
@@ -737,6 +739,18 @@ class ModelRun:
             name=DnoraDataType.SPECTRALGRID.name, freq=freq, dirs=dirs
         )
 
+    def set_nested_grid(self, grid: Grid) -> None:
+        """Sets up a nested run for the provided grid"""
+
+        self._nest = self.__class__(
+            grid, start_time=self.start_time(), end_time=self.end_time()
+        )
+        msg.header(self.nest(), f"Setting up a nested run {grid.name}...")
+
+    def nest(self) -> ModelRun:
+        """Returns the spectral grid object if exists."""
+        return self._nest
+
     def spectral_grid(self) -> Ice:
         """Returns the spectral grid object if exists."""
         return self._dnora_objects.get(DnoraDataType.SPECTRALGRID)
@@ -890,7 +904,9 @@ class ModelRun:
         obj_type = data_type_from_string(obj_type)
         return self._dnora_objects.get(obj_type)
 
-    def __setitem__(self, obj_type: Union[DnoraDataType, str], value: DnoraObject) -> None:
+    def __setitem__(
+        self, obj_type: Union[DnoraDataType, str], value: DnoraObject
+    ) -> None:
         """Sets a Dnora item"""
         obj_type = data_type_from_string(obj_type)
         self._dnora_objects[obj_type] = value

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -746,7 +746,10 @@ class ModelRun:
         self._nest = self.__class__(
             grid, start_time=self.start_time(), end_time=self.end_time()
         )
-        msg.header(self.nest(), f"Setting up a nested run {grid.name}...")
+        msg.header(
+            self.nest(),
+            f"Setting up a nested run {grid.name} inside {self.grid().name}...",
+        )
         self.nest()._parent = self
 
     def nest(self) -> ModelRun:

--- a/dnora/modelrun/modelrun.py
+++ b/dnora/modelrun/modelrun.py
@@ -148,6 +148,7 @@ class ModelRun:
         self.name = name
         self._post_processing = None
         self._nest = None
+        self._parent = None
 
         self.plot = dnplot.Matplotlib(self)
         self._dnora_objects: dict[DnoraDataType, DnoraObject] = {
@@ -746,10 +747,15 @@ class ModelRun:
             grid, start_time=self.start_time(), end_time=self.end_time()
         )
         msg.header(self.nest(), f"Setting up a nested run {grid.name}...")
+        self.nest()._parent = self
 
     def nest(self) -> ModelRun:
-        """Returns the spectral grid object if exists."""
+        """Returns the nested ModelRun object"""
         return self._nest
+
+    def parent(self) -> ModelRun:
+        """Returns the parent ModelRun object of the nested ModelRun."""
+        return self._parent
 
     def spectral_grid(self) -> Ice:
         """Returns the spectral grid object if exists."""

--- a/dnora/modelrun/templates.py
+++ b/dnora/modelrun/templates.py
@@ -4,7 +4,7 @@ from dnora.read.generic import ConstantData
 from dnora.type_manager.dnora_types import DnoraDataType
 import dnora
 import warnings
-from functools import wraps
+
 
 # DEPRECIATE = ["nora3", "era5", "noaa", "nchmf"]
 DEPRECIATE = []
@@ -52,7 +52,7 @@ class Constant(ModelRun):
     }
 
 
-@deprecated_class("MET Norway's", "metno")
+# @deprecated_class("MET Norway's", "metno")
 class NORA3(ModelRun):
     _reader_dict = {
         DnoraDataType.SPECTRA: dnora.read.spectra.metno.NORA3(),
@@ -61,7 +61,7 @@ class NORA3(ModelRun):
     }
 
 
-@deprecated_class("MET Norway's", "metno")
+# @deprecated_class("MET Norway's", "metno")
 class WAM4km(ModelRun):
     _reader_dict = {
         DnoraDataType.SPECTRA: dnora.read.spectra.metno.WAM4km(),
@@ -69,7 +69,7 @@ class WAM4km(ModelRun):
     }
 
 
-@deprecated_class("MET Norway's", "metno")
+# @deprecated_class("MET Norway's", "metno")
 class WW3_4km(ModelRun):
     _reader_dict = {
         DnoraDataType.SPECTRA: dnora.read.spectra.metno.WW3_4km(),
@@ -77,7 +77,7 @@ class WW3_4km(ModelRun):
     }
 
 
-@deprecated_class("MET Norway's", "metno")
+# @deprecated_class("MET Norway's", "metno")
 class CLIMAREST(ModelRun):
     _reader_dict = {
         DnoraDataType.SPECTRA: dnora.read.spectra.metno.CLIMAREST(),
@@ -86,7 +86,7 @@ class CLIMAREST(ModelRun):
     }
 
 
-@deprecated_class("ERA5", "era5")
+# @deprecated_class("ERA5", "era5")
 class ERA5(ModelRun):
     _reader_dict = {
         DnoraDataType.SPECTRA: dnora.read.spectra.ec.ERA5(),
@@ -95,21 +95,21 @@ class ERA5(ModelRun):
     }
 
 
-@deprecated_class("NOAA", "noaa")
+# @deprecated_class("NOAA", "noaa")
 class PacIOOS(ModelRun):
     _reader_dict = {
         DnoraDataType.WIND: dnora.read.wind.noaa.PacIOOS(),
     }
 
 
-@deprecated_class("NOAA", "noaa")
+# @deprecated_class("NOAA", "noaa")
 class NCEP(ModelRun):
     _reader_dict = {
         DnoraDataType.WIND: dnora.read.wind.noaa.NCEP(),
     }
 
 
-@deprecated_class("NCHMF", "nchmf")
+# @deprecated_class("NCHMF", "nchmf")
 class NCHMF(ModelRun):
     _reader_dict = {
         # DnoraDataType.SPECTRA: dnora.read.spectra.nchmf.SWAN(),

--- a/dnora/modelrun/templates.py
+++ b/dnora/modelrun/templates.py
@@ -4,7 +4,7 @@ from dnora.read.generic import ConstantData
 from dnora.type_manager.dnora_types import DnoraDataType
 import dnora
 import warnings
-
+import dnora.read.wind, dnora.read.spectra, dnora.read.spectra1d, dnora.read.waveseries, dnora.read.ice, dnora.read.waterlevel, dnora.read.current, dnora.read.grid
 
 # DEPRECIATE = ["nora3", "era5", "noaa", "nchmf"]
 DEPRECIATE = []

--- a/dnora/read/__init__.py
+++ b/dnora/read/__init__.py
@@ -1,1 +1,0 @@
-from . import spectra, spectra1d, wind, waterlevel, waveseries, ice, current, grid

--- a/dnora/read/abstract_readers.py
+++ b/dnora/read/abstract_readers.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 from dnora.cacher.caching_strategies import CachingStrategy
 
 from dnora.process.gridded import FillNaNs
+from dnora.utils.io import get_url
 
 
 class DataReader(ABC):
@@ -93,16 +94,16 @@ class DataReader(ABC):
         source: DataSource,
         tile: Optional[str] = None,
         tile_name: Optional[str] = None,
-        strict:bool = True, 
+        strict: bool = True,
     ) -> str:
         default_folder = self._default_folders.get(source)
         if source in [DataSource.REMOTE, DataSource.LOCAL]:
             folder = folder or default_folder
             if folder is not None:
-                if tile is not None:
-                    folder = re.sub("#TILE", tile, folder)
                 if tile_name is not None:
                     folder = re.sub("#TILENAME", tile_name, folder)
+                if tile is not None:
+                    folder = re.sub("#TILE", tile, folder)
                 return folder
         else:
             if folder is None:
@@ -119,8 +120,7 @@ class DataReader(ABC):
                 return folder
         if strict:
             raise ValueError(f"No folder is defined for source {source}!")
-        return ''
-        
+        return ""
 
     def _filename(
         self,
@@ -128,17 +128,17 @@ class DataReader(ABC):
         source: DataSource,
         tile: Optional[str] = None,
         tile_name: Optional[str] = None,
-        strict:bool = True, 
+        strict: bool = True,
     ) -> str:
         if filename is None:
             filename = self._default_filenames.get(source)
         if filename is None:
             filename = self._default_filename
         if filename is None:
-            if strict: 
+            if strict:
                 raise ValueError(f"No filename is defined for source {source}!")
-            return ''
-            
+            return ""
+
         if tile_name is not None:
             filename = re.sub("#TILENAME", tile_name, filename)
         if tile is not None:

--- a/dnora/read/spectra/__init__.py
+++ b/dnora/read/spectra/__init__.py
@@ -1,2 +1,2 @@
-from .spectral_readers import SWAN_Ascii, Spectra1DToSpectra
+from .spectral_readers import SWAN_Ascii, SWAN_Nc, Spectra1DToSpectra
 from . import metno, ec  # , nchmf

--- a/dnora/read/spectra/metno.py
+++ b/dnora/read/spectra/metno.py
@@ -169,6 +169,3 @@ class CLIMAREST(SpectralProductReader):
 
     def post_processing(self):
         return RemoveNanTimes()
-
-
-WW3

--- a/dnora/read/spectra/metno.py
+++ b/dnora/read/spectra/metno.py
@@ -69,7 +69,7 @@ class WW3_4km(SpectralProductReader):
         },
         tile="POI",
         ds_creator_function=partial(basic_xarray_read, inds_var="x"),
-        convention=SpectralConvention.WW3,
+        convention=SpectralConvention.OCEAN,
         default_data_source=DataSource.REMOTE,
     )
 
@@ -169,3 +169,6 @@ class CLIMAREST(SpectralProductReader):
 
     def post_processing(self):
         return RemoveNanTimes()
+
+
+WW3

--- a/dnora/read/spectra/metno.py
+++ b/dnora/read/spectra/metno.py
@@ -100,7 +100,7 @@ class WAM800(SpectralProductReader):
         },
         ds_creator_function=partial(basic_xarray_read, inds_var="x"),
         convention=SpectralConvention.OCEAN,
-        default_data_source=DataSource.IMMUTABLE,
+        default_data_source=DataSource.REMOTE,
         ds_aliases={"SPEC": gp.wave.Efth},
     )
 

--- a/dnora/read/spectra/spectral_readers.py
+++ b/dnora/read/spectra/spectral_readers.py
@@ -14,6 +14,21 @@ import xarray as xr
 import geo_parameters as gp
 from geo_skeletons import PointSkeleton
 from dnora.utils.io import get_url
+from dnora.read.generic import PointNetcdf
+
+
+class SWAN_Nc(PointNetcdf):
+    def convention(self) -> str:
+        return SpectralConvention.MET
+
+    def __call__(self, *args, **kwargs):
+        ds = super().__call__(*args, **kwargs)
+        theta = ds.dirs.values
+        dd = np.mod(np.rad2deg(theta) + 360, 360)
+        ds["dirs"] = np.round(dd, 2)
+        ds = ds.sortby("dirs")
+        return ds
+
 
 class SWAN_Ascii(SpectralDataReader):
     def convention(self) -> SpectralConvention:

--- a/dnora/spectra/spectra.py
+++ b/dnora/spectra/spectra.py
@@ -157,6 +157,10 @@ class Spectra(PointSkeleton):
 
 def directions_consistent_with_convention(dirs, convention) -> bool:
     convention = spectral_convention_from_string(convention)
+    if convention in [SpectralConvention.UNDEFINED]:
+        raise Warning(
+            f"Marking convention {convention}, so cannot keep track of wave directionality! {dirs}"
+        )
     if convention in [SpectralConvention.WW3, SpectralConvention.MATHVEC]:
         if np.all(np.diff(dirs) > 0):
             raise Warning(

--- a/dnora/utils/grid.py
+++ b/dnora/utils/grid.py
@@ -3,12 +3,13 @@ import numpy as np
 
 def data_covers_grid(skeleton, grid):
     """Checks if a given skeleton covers a given grid"""
-    for coord in ['lon', 'lat']:
+    for coord in ["lon", "lat"]:
         if skeleton.edges(coord)[0] > grid.edges(coord)[0]:
             return False
         if skeleton.edges(coord)[-1] < grid.edges(coord)[-1]:
             return False
     return True
+
 
 def identify_boundary_edges(boundary_mask: np.ndarray) -> list[str]:
     """Identifies which edges has some boundary points
@@ -118,20 +119,6 @@ def get_coords_for_boundary_edges(
             lat.append(lat_edges[0])
 
     return np.array(lon), np.array(lat)
-
-
-def create_swan_segment_coords(boundary_mask, lon_edges, lat_edges):
-    """Createsa longitude and latitude arrays for the SWAN BOUND SEGEMENT
-    command based on boundary mask.
-    Identifies edges (north, south etc.) and sets all the points on the edges
-    as boundary points.
-    If no continuous boundary can be identified, it returns empty list.
-    """
-
-    edge_list = identify_boundary_edges(boundary_mask)
-    clean_edge_list = create_ordered_boundary_list(edge_list)
-    lon, lat = get_coords_for_boundary_edges(clean_edge_list, lon_edges, lat_edges)
-    return lon, lat
 
 
 def is_gridded(data: np.ndarray, lon: np.ndarray, lat: np.ndarray) -> bool:

--- a/tests/test_grid/test_boundary_points.py
+++ b/tests/test_grid/test_boundary_points.py
@@ -6,8 +6,8 @@ from dnora.utils.grid import (
     identify_boundary_edges,
     create_ordered_boundary_list,
     get_coords_for_boundary_edges,
-    create_swan_segment_coords,
 )
+from dnora.executer.inputfile.swan_functions import create_swan_segment_coords
 import numpy as np
 from copy import copy
 

--- a/tests/test_readers/test_remote_current_readers.py
+++ b/tests/test_readers/test_remote_current_readers.py
@@ -43,7 +43,7 @@ def test_norkyst800_2017(grid, timevec2017):
     assert model.current().u(strict=True) is not None
     assert model.current().v(strict=True) is not None
 
-
+@pytest.mark.internal
 @pytest.mark.remote
 def test_norfjords160(grid160, timevec):
     model = dn.modelrun.ModelRun(grid160, year=2022, month=4, day=1)


### PR DESCRIPTION
Added Possibilities to nest SWAN model runs

Minimal example to do a double nested run:

```
import dnora as dn

grid = dn.grid.EMODNET(lon=(5.21, 6.66), lat=(62.25, 62.89), name="sula500")
grid.set_spacing(dm=500)
grid.import_topo()
grid.mesh_grid()
grid.set_boundary_points(dn.grid.mask.Edges(edges=["N", "W"]))

grid2 = dn.grid.EMODNET(lon=(5.5, 6.66), lat=(62.25, 62.6), name="sula200")
grid2.set_spacing(dm=200)
grid2.import_topo()
grid2.mesh_grid()

grid3 = dn.grid.EMODNET(lon=(5.8, 6.1), lat=(62.4, 62.5), name="sula50")
grid3.set_spacing(dm=50)
grid3.import_topo()
grid3.mesh_grid()

model = dn.modelrun.NORA3(grid, year=2020, month=1, day=20)
model.set_nested_grid(grid2)
model.nest().set_nested_grid(grid3)

model.import_wind()
model.import_spectra()
# Only the smallest domain will use current forcing
model.nest().nest().import_current(dn.read.current.metno.NorKyst800())

# Exporter works on all three grids
exporter = dn.export.SWAN(model)
exporter.export_grid()
exporter.export_wind()
exporter.export_spectra()
exporter.export_current()

# Executer works on all three runs
exe = dn.executer.SWAN(model)
exe.write_input_file()
exe.run_model()
```
Also added a reader for SWAN netcdf spectra (`dn.read.spectra.SWAN_Nc`) and fixed the spectral convention of the operational WW3 spectral reader from WW3 to OCEAN.